### PR TITLE
Use OptionParser to handle CLI switches

### DIFF
--- a/lib/bunup/cli.rb
+++ b/lib/bunup/cli.rb
@@ -11,14 +11,9 @@ module Bunup
         'Continue? [y/N] '.freeze
     UPDATING_MSG_FMT = '(%<remaining>s) Updating %<gem_name>s ' \
       '%<installed_version>s -> %<newest_version>s'.freeze
-    USAGE = <<-TEXT.freeze
-Usage:
-  bunup --all
-  bunup <gem_name> [<gem_name>...]
-TEXT
 
     def initialize(args)
-      abort(USAGE) if args.include?('-h') || args.include?('--help')
+      @options = ::Bunup::Options.parse!(args)
       @args = args
       @exit_status = true
     end
@@ -58,7 +53,7 @@ TEXT
     end
 
     def bunup_all?
-      @args.include?('--all') || @args.empty?
+      @options.all
     end
 
     def bunup_many?

--- a/lib/bunup/options.rb
+++ b/lib/bunup/options.rb
@@ -1,0 +1,32 @@
+require 'optionparser'
+require 'ostruct'
+
+module Bunup
+  # Handle command-line switches
+  class Options < ::OpenStruct
+    def self.parse!(args)
+      args = ['--all'] if args.empty?
+      options = new
+      opt_parser = ::OptionParser.new do |opts|
+        opts.banner = 'Usage: bunup [options] | <gem_name> [<gem_name>...]'
+        opts.program_name = 'bunup'
+        opts.version = ::Bunup::VERSION
+
+        opts.on('--all', 'Update all outdated gems (default)') do
+          options.all = true
+        end
+
+        opts.on('-h', '--help', 'Prints this help') do
+          puts opts
+          exit
+        end
+      end
+      opt_parser.parse!(args)
+      options
+    rescue OptionParser::InvalidOption => e
+      puts e
+      puts opt_parser
+      abort
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1 
Fixes #2 

@sbleon This PR uses OptionParser for more comprehensive CLI switch handling. It includes a `-v`/`--version` and invalid option handling.